### PR TITLE
Add maintenance mode warning to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PyNGL
 
+> [!WARNING]
+> **PyNGL was placed in maintenance mode as of November of 2020.** You can find more details in the [full announcement here](https://geocat.ucar.edu/blog/2020/11/11/November-2020-update).
+
 PyNGL ("pingle") is a Python module built on top of [NCL](http://www.ncl.ucar.edu)'s graphics library, which produces publication-quality, two-dimensional visualizations tailored for climate and weather data.
 
 Interfaces exist for the display of:


### PR DESCRIPTION
Adds a maintenance mode warning to the README.md with a link to the full announcement.

Relates to #57.  I'm a bit hesitant to close the issue since I think we should at least add a note and link to the updated announcement in the documentation as well.